### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   check-code:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/aginies/virtui-manager/security/code-scanning/1](https://github.com/aginies/virtui-manager/security/code-scanning/1)

In general, the fix is to explicitly set a `permissions` block that grants only the minimum required scopes for the `GITHUB_TOKEN`. Since this workflow only checks out code and runs local scripts, it only needs read access to repository contents; `contents: read` is sufficient. We can add this either at the workflow root (applies to all jobs) or per job; here we will add it at the job level for `check-code`.

Concretely, in `.github/workflows/ci.yml`, under `jobs:`, in the `check-code` job definition, add a `permissions:` section with `contents: read` before `runs-on: ubuntu-latest`. This does not change existing functionality: `actions/checkout@v4` works with `contents: read`, and no step requires write access to any GitHub resource. No new imports or external libraries are needed; it is purely a YAML configuration change inside the shown workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
