### PR TITLE
Potential fix for code scanning alert no. 36: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI Check
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/aginies/virtui-manager/security/code-scanning/36](https://github.com/aginies/virtui-manager/security/code-scanning/36)

In general, the fix is to add an explicit `permissions` block to the workflow (or to each job) specifying the least privileges required. For this CI pipeline, the only GitHub permission actually needed is the ability for `actions/checkout` to read the repository contents. No job writes anything back to GitHub, so we can safely set `contents: read` and leave everything else at the default of `none`.

The best minimal fix without changing functionality is to add a top-level `permissions` block just under the `name:` (and before `on:`), so that it applies to all three jobs: `static-checks`, `lint`, and `tests`. This block will read:

```yaml
permissions:
  contents: read
```

This documents the intent and ensures that even if the repository/org default changes or the workflow is copied elsewhere, the `GITHUB_TOKEN` for these jobs remains read-only. No additional imports, methods, or other code changes are necessary.

Concretely, edit `.github/workflows/ci.yml` by inserting the `permissions` section after line 1 and before the `on:` block starting at line 3.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
